### PR TITLE
Fixed routes definition in DeploymentManifest. Bumped version to 1.1.2

### DIFF
--- a/IoTEdgeObjectModel.csproj
+++ b/IoTEdgeObjectModel.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>IoTEdgeObjectModel</PackageId>
-    <Version>1.1.1</Version>
+    <Version>1.1.2</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/src/Models/DeploymentManifest.cs
+++ b/src/Models/DeploymentManifest.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Azure.Devices
             /// Gets or sets routes.
             /// </summary>
             [JsonProperty("routes")]
-            public Dictionary<string, string> Routes { get; set; }
+            public Dictionary<string, Route> Routes { get; set; }
 
             /// <summary>
             /// Gets or sets storeAndForwardConfiguration.


### PR DESCRIPTION
Without this fix getting the deployment manifest crashes when routes are defined.